### PR TITLE
Add AppTransportSecurity exception for HTTP traffic

### DIFF
--- a/Sample/Vungle Sample App/Vungle Sample App-Info.plist
+++ b/Sample/Vungle Sample App/Vungle Sample App-Info.plist
@@ -55,7 +55,16 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleGetInfoString</key>
+	<string></string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
# Overview

Updated sample application to include NSAppTransportSecurity exception required for compatibility w/ iOS 9 
