### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ To get up and running with Vungle, you'll need to [Create an Account With Vungle
 
 Once you've created an account you can follow our [Getting Started for iOS Guide](https://support.vungle.com/hc/en-us/articles/204430550-Getting-Started-with-Vungle-iOS-SDK) to complete the integration. Remember to get the Vungle App ID from the Vungle dashboard.
 
-The Vungle iOS SDK can also be installed via [Cocoapods](https://cocoapods.org/).  To install the Vungle iOS-SDK via Cocoapods add the following line to your Podfile and re-run the `pod install` command:
+The Vungle iOS SDK can also be installed via [CocoaPods](https://cocoapods.org/).  To install the Vungle iOS-SDK via CocoaPods add the following line to your Podfile and re-run the `pod install` command:
 
 ```ruby
 pod "VungleSDK-iOS"
 ```
 
-The latest information around our Cocoapods support can be found at the [VungleSDK-iOS Cocoapods Page](https://cocoapods.org/pods/VungleSDK-iOS)
+The latest information around our CocoaPods support can be found at the [VungleSDK-iOS CocoaPods Page](https://cocoapods.org/pods/VungleSDK-iOS)
 
 ### Version Info
 The Vungle iOS SDK only supports iOS 7+ and supports both 32bit and 64bit apps.  


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
