### PR TITLE
Remove EXCLUDED_ARCHS - no longer needed

### DIFF
--- a/VungleSDK-iOS.podspec
+++ b/VungleSDK-iOS.podspec
@@ -27,6 +27,4 @@ s.frameworks = 'AdSupport', 'AudioToolbox', 'AVFoundation', 'CFNetwork', 'CoreGr
 s.weak_framework = 'WebKit', 'UIKit', 'Foundation'
 s.libraries = 'z'
 
-s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64 arm64e armv7 armv7s', 'EXCLUDED_ARCHS[sdk=iphoneos*]' => 'i386 x86_64'}
-
 end


### PR DESCRIPTION
The XCFramework already contains all the relevant slices for both iOS devices and iOS Simulators, the limitation is unnecessary.